### PR TITLE
Use code format for what should be typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Use `:Mon` to enable the bindings and `:Moff` to disable them.
 
 Some examples:
 
-1. To get〈ψ|∂⃡|ϕ〉type \<\psi|\partial\^<->|\phi\\>
-2. To get x⃗·y⃗ = ∑ᵢxᵢyᵢ type x\^->\\.y\^-> = \sum\_ix\_iy\_i
-3. To get ∫∏ᵢdxᵢexp(-½xᵢ²) type \int\prod\_idx\_iexp(-\1/2x\_i\^2)
-4. To get ∬dω = ∮ω type \iintd\omega = \oint\omega
-5. To get … → H̃₀(A∩B) → H̃₀(A)⊕H̃₀(B) → H̃₀(X) → 0 type \ldots \\-> H\\^\~\\_0(A\capB) \\-> H\\^\~\\_0(A)\oplusH\\^\~\\_0(B) \\-> H\\^\~\\_0(X) \\-> 0
+1. To get 〈ψ|∂⃡|ϕ〉 type `\<\psi|\partial\^<->|\phi\\>`
+2. To get x⃗·y⃗ = ∑ᵢxᵢyᵢ type `x\^->\\.y\^-> = \sum\_ix\_iy\_i`
+3. To get ∫∏ᵢdxᵢexp(-½xᵢ²) type `\int\prod\_idx\_iexp(-\1/2x\_i\^2)`
+4. To get ∬dω = ∮ω type `\iintd\omega = \oint\omega`
+5. To get … → H̃₀(A∩B) → H̃₀(A)⊕H̃₀(B) → H̃₀(X) → 0 type `\ldots \\-> H\\^\~\\_0(A\capB) \\-> H\\^\~\\_0(A)\oplusH\\^\~\\_0(B) \\-> H\\^\~\\_0(X) \\-> 0`
 
 Have a look in math.vim for the rest.
 


### PR DESCRIPTION
* Improve readability
* Fix example 1 by adding `\` missing from GitHub's rendering